### PR TITLE
enable different header prefixes

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -33,6 +33,10 @@ class NTLMClient {
   /// The NT hash of the user's password
   String ntPassword;
 
+  /// The prefix for the www-authenticaate / authorization header
+  /// Usually either of 'NTLM' or 'Negotiate'
+  String headerPrefix;
+
   /// The HTTP client used by this NTLMClient to make requests
   Client _inner;
 
@@ -70,6 +74,7 @@ class NTLMClient {
     this.lmPassword,
     this.ntPassword,
     Client inner,
+    this.headerPrefix = 'NTLM',
   }) {
     if (password == null && (lmPassword == null || ntPassword == null)) {
       throw ArgumentError(
@@ -94,13 +99,14 @@ class NTLMClient {
     var res0 = await request(headers);
     if (res0.statusCode == 200 ||
         !res0.headers.containsKey(_wwwAuthenticateHeader) ||
-        !res0.headers[_wwwAuthenticateHeader].contains('NTLM')) {
+        !res0.headers[_wwwAuthenticateHeader].contains(headerPrefix)) {
       return res0;
     }
 
     var msg1 = createType1Message(
       domain: domain,
       workstation: workstation,
+      headerPrefix: headerPrefix
     );
 
     var res2 = await request({
@@ -112,14 +118,14 @@ class NTLMClient {
     String rawMsg2;
     for (var res2AuthenticatePart in res2AuthenticateParts) {
       var trimmedPart = res2AuthenticatePart.trim();
-      if (trimmedPart.startsWith('NTLM ')) {
+      if (trimmedPart.startsWith('${headerPrefix} ')) {
         rawMsg2 = trimmedPart;
         break;
       }
     }
 
     if (rawMsg2 == null) return res0;
-    var msg2 = parseType2Message(rawMsg2);
+    var msg2 = parseType2Message(rawMsg2, headerPrefix);
 
     var msg3 = createType3Message(
       msg2,
@@ -129,6 +135,7 @@ class NTLMClient {
       password: password,
       lmPassword: lmPassword,
       ntPassword: ntPassword,
+      headerPrefix: headerPrefix
     );
 
     var res3 = await request({

--- a/lib/src/messages/type1.dart
+++ b/lib/src/messages/type1.dart
@@ -4,7 +4,7 @@ import 'package:ntlm/src/messages/common/utils.dart';
 import 'package:ntlm/src/messages/common/flags.dart' as flags;
 
 /// Creates a type 1 NTLM message from the [domain] and [workstation]
-String createType1Message({String domain = '', String workstation = ''}) {
+String createType1Message({String domain = '', String workstation = '', String headerPrefix = 'NTLM'}) {
   domain = domain.toUpperCase();
   workstation = workstation.toUpperCase();
   const signature = 'NTLMSSP\x00';
@@ -83,5 +83,5 @@ String createType1Message({String domain = '', String workstation = ''}) {
   write(buf, ascii.encode(domain), pos, domain.length);
   pos += domain.length;
 
-  return 'NTLM ${base64Encode(buf.buffer.asUint8List())}';
+  return '${headerPrefix} ${base64Encode(buf.buffer.asUint8List())}';
 }

--- a/lib/src/messages/type2.dart
+++ b/lib/src/messages/type2.dart
@@ -44,9 +44,9 @@ class Type2Message {
 }
 
 /// Extract the information from the type 2 [rawMsg] into an object.
-Type2Message parseType2Message(String rawMsg) {
-  if (rawMsg.startsWith('NTLM ')) {
-    rawMsg = rawMsg.substring('NTLM '.length);
+Type2Message parseType2Message(String rawMsg, [String headerPrefix = 'NTLM']) {
+  if (rawMsg.startsWith('${headerPrefix} ')) {
+    rawMsg = rawMsg.substring('${headerPrefix} '.length);
   }
 
   var buf = base64Decode(rawMsg).buffer;

--- a/lib/src/messages/type3.dart
+++ b/lib/src/messages/type3.dart
@@ -14,6 +14,7 @@ String createType3Message(
   String password,
   String lmPassword,
   String ntPassword,
+  String headerPrefix = 'NTLM'
 }) {
   if (password == null && (lmPassword == null || ntPassword == null)) {
     throw ArgumentError(
@@ -205,5 +206,5 @@ String createType3Message(
       encryptedRandomSessionKeyBytes.length);
   pos += encryptedRandomSessionKeyBytes.length;
 
-  return 'NTLM ${base64Encode(buf.buffer.asUint8List())}';
+  return '${headerPrefix} ${base64Encode(buf.buffer.asUint8List())}';
 }


### PR DESCRIPTION
Hi!

I made some changes to support NTLM as a fallback for `WWW-Authenticate: Negotiate`. As you can see in the [Microsoft Docs on HTTP Authentication](https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/understanding-http-authentication) NTLM can be used as a fallback if the Kerberos protocol is unavailable. However, if the Kerberos protocol is unavailable, a server might expect and send messages using `Negotiate <base64 encoded message>`.  (I found no documentation on whether the header prefix may change to `NTLM`, but in my use case it only works with `Negotiate`)

Therefore, I introduced a new variable `headerPrefix` in the `NTLMClient` and passed it to all helper functions for message 1-3. All new `headerPrefix` parameters for constructors/functions have their default value set to `NTLM` and are optional, to provide full backwards compatibility.